### PR TITLE
Fixes the failing pip-chill command and Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
   - "pypy3"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install tox-travis
+install: pip install tox-travis  && if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
 
 # command to run tests, e.g. python setup.py test
 script: tox

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Lists installed packages that are not dependencies of others"""
 
-import pip
+import pkg_resources
 
-from utils import Distribution
+from .utils import Distribution
 
 
 def chill(show_all=False):
@@ -17,7 +17,7 @@ def chill(show_all=False):
     distributions = {}
     dependencies = {}
 
-    for distribution in pip.get_installed_distributions():
+    for distribution in pkg_resources.working_set:
         if distribution.key in ignored_packages:
             continue
 


### PR DESCRIPTION
#### What does this PR do?
Fixes the failing pip-chill command execution
#### Description of Task to be completed?
- Fix the error that occurs when `pip-chill` is run
- Fix the tests on Travis
#### How should this be manually tested?
First off activate a python environment then run:
```bash
python setup.py install
pip-chill
```
The output should have no error.
#### Any background context you want to provide?
- @LevN0 explains what's up with Travis as far as Python 3.3 is concerned [here](https://github.com/aws/base64io-python/issues/4).
- I have solved @ebrensi's PR #15 issue of the tox tests failing in Python 3.3
- This [StackOverflow thread](https://stackoverflow.com/questions/49923671/are-there-any-function-replacement-for-pip-get-installed-distributions-in-pip) led me to the alternative of `pip.get_installed_distributions` which is no longer contained in `pip 10.0.0 version onwards`