### PR TITLE
Adding omit-self

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ On your terminal, run::
  cookiecutter==1.4.0
  coverage==3.7.1
  django-argonauts==1.0.1
+ pip-chill==1.0.0
  ...
 
 Or, if you want it without version numbers::
@@ -71,6 +72,19 @@ Or, if you want it without version numbers::
  cookiecutter
  coverage
  django-argonauts
+ pip-chill
+ ...
+
+Or, if you dont want pip-chill itself listed::
+
+ $ pip-chill --omit-self
+ asciitree==0.3.1
+ autopep8==1.2.4
+ beautifulsoup4==4.4.0
+ bleach==1.4.1
+ cookiecutter==1.4.0
+ coverage==3.7.1
+ django-argonauts==1.0.1
  ...
 
 Or, if you want to list package dependencies too::
@@ -83,6 +97,7 @@ Or, if you want to list package dependencies too::
  cookiecutter==1.4.0
  coverage==3.7.1
  django-argonauts==1.0.1
+ pip-chill==1.0.0
  # arrow==0.10.0 # Installed as dependency for jinja2-time
  # binaryornot==0.4.4 # Installed as dependency for cookiecutter
  # chardet==3.0.4 # Installed as dependency for binaryornot

--- a/pip_chill/cli.py
+++ b/pip_chill/cli.py
@@ -35,9 +35,16 @@ def main():
         dest="verbose",
         help="list commented out dependencies too.",
     )
+    parser.add_argument(
+        "-o",
+        "--omit-self",
+        action="store_true",
+        dest="omit_self",
+        help="dont display pip-chill itself",
+    )
     args = parser.parse_args()
 
-    distributions, dependencies = pip_chill.chill(show_all=args.show_all)
+    distributions, dependencies = pip_chill.chill(show_all=args.show_all, omit_self=args.omit_self)
     for package in distributions:
         if args.no_version:
             print(package.get_name_without_version())

--- a/pip_chill/cli.py
+++ b/pip_chill/cli.py
@@ -44,7 +44,10 @@ def main():
     )
     args = parser.parse_args()
 
-    distributions, dependencies = pip_chill.chill(show_all=args.show_all, omit_self=args.omit_self)
+    distributions, dependencies = pip_chill.chill(
+        show_all=args.show_all,
+        omit_self=args.omit_self
+    )
     for package in distributions:
         if args.no_version:
             print(package.get_name_without_version())

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -51,11 +51,14 @@ class Distribution:
         return hash(self.name)
 
 
-def chill(show_all=False):
+def chill(show_all=False, omit_self=False):
     if show_all:
         ignored_packages = ()
     else:
         ignored_packages = {"pip", "wheel", "setuptools", "pkg-resources"}
+
+    if omit_self:
+        ignored_packages.add("pip-chill")
 
     # Gather all packages that are requirements and will be auto-installed.
     distributions = {}

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -40,9 +40,9 @@ class Distribution:
         if self is other:
             return True
         elif isinstance(other, Distribution):
-            return True if self.name == other.name else False
+            return self.name == other.name
         else:
-            return True if self.name == other else False
+            return self.name == other
 
     def __lt__(self, other):
         return self.name < other.name

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
-bandit
+bandit==1.6.2; python_version < "3"
+bandit; python_version >= "3"
 bumpversion
 click
 coverage

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -121,7 +121,9 @@ class TestPip_chill(unittest.TestCase):
 
         result = os.popen(command).read()
         for package in ["wheel", "setuptools", "pip"]:
-            self.assertFalse(any(p.startswith(package + "==") for p in result.split("\n")))
+            self.assertFalse(
+                any(p.startswith(package + "==") for p in result.split("\n"))
+            )
 
     def test_command_line_interface_all(self):
         argument = "--all"
@@ -175,7 +177,9 @@ class TestPip_chill(unittest.TestCase):
         self.assertEqual(returncode, 0)
 
         result = os.popen(command).read()
-        self.assertFalse(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
+        self.assertFalse(
+            any(p.startswith("pip-chill" + "==") for p in result.split("\n"))
+        )
 
     def test_command_line_interface_short_omit_self_on_request(self):
         argument = "-o"
@@ -185,7 +189,9 @@ class TestPip_chill(unittest.TestCase):
         self.assertEqual(returncode, 0)
 
         result = os.popen(command).read()
-        self.assertFalse(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
+        self.assertFalse(
+            any(p.startswith("pip-chill" + "==") for p in result.split("\n"))
+        )
 
     def test_command_line_interface_doesnt_omit_self_by_default(self):
         argument = ""
@@ -195,7 +201,9 @@ class TestPip_chill(unittest.TestCase):
         self.assertEqual(returncode, 0)
 
         result = os.popen(command).read()
-        self.assertTrue(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
+        self.assertTrue(
+            any(p.startswith("pip-chill" + "==") for p in result.split("\n"))
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -121,9 +121,7 @@ class TestPip_chill(unittest.TestCase):
 
         result = os.popen(command).read()
         for package in ["wheel", "setuptools", "pip"]:
-            self.assertFalse(
-                any([p.startswith(package + "==") for p in result.split("\n")])
-            )
+            self.assertFalse(any(p.startswith(package + "==") for p in result.split("\n")))
 
     def test_command_line_interface_all(self):
         argument = "--all"
@@ -168,6 +166,36 @@ class TestPip_chill(unittest.TestCase):
             self.assertEqual(returncode, 512)
         else:
             self.assertEqual(returncode, 2)
+
+    def test_command_line_interface_omit_self_on_request(self):
+        argument = "--omit-self"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
+
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
+
+        result = os.popen(command).read()
+        self.assertFalse(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
+
+    def test_command_line_interface_short_omit_self_on_request(self):
+        argument = "-o"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
+
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
+
+        result = os.popen(command).read()
+        self.assertFalse(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
+
+    def test_command_line_interface_doesnt_omit_self_by_default(self):
+        argument = ""
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
+
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
+
+        result = os.popen(command).read()
+        self.assertTrue(any(p.startswith("pip-chill" + "==") for p in result.split("\n")))
 
 
 if __name__ == "__main__":

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -10,11 +10,16 @@ Tests for `pip_chill` module.
 
 
 import os
+import platform
 import sys
 import unittest
 
 from pip_chill import cli, pip_chill
 from pip_chill.pip_chill import Distribution
+
+PIP_CHILL_CLI_FULL_PATH = cli.__file__
+PYTHON_EXE_PATH = sys.executable
+is_windows = any(platform.win32_ver())
 
 
 class TestPip_chill(unittest.TestCase):
@@ -54,7 +59,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertEqual(self.distribution_2, self.distribution_2.name)
 
     def test_command_line_interface_help(self):
-        command = "pip_chill/cli.py --help"
+        argument = "--help"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -66,7 +72,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertIn("show this help message and exit", result)
 
     def test_command_line_interface_no_version(self):
-        command = "pip_chill/cli.py --no-version"
+        argument = "--no-version"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -75,7 +82,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertNotIn("==", result)
 
     def test_command_line_interface_verbose(self):
-        command = "pip_chill/cli.py --verbose"
+        argument = " --verbose"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -84,7 +92,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertIn("# Installed as dependency for", result)
 
     def test_command_line_interface_short_verbose(self):
-        command = "pip_chill/cli.py -v"
+        argument = "-v"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -93,7 +102,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertIn("# Installed as dependency for", result)
 
     def test_command_line_interface_verbose_no_version(self):
-        command = "pip_chill/cli.py --verbose --no-version"
+        argument = "--verbose --no-version"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -103,7 +113,8 @@ class TestPip_chill(unittest.TestCase):
         self.assertIn("# Installed as dependency for", result)
 
     def test_command_line_interface_omits_ignored(self):
-        command = "pip_chill/cli.py"
+        argument = ""
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -115,7 +126,8 @@ class TestPip_chill(unittest.TestCase):
             )
 
     def test_command_line_interface_all(self):
-        command = "pip_chill/cli.py --all"
+        argument = "--all"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -125,7 +137,8 @@ class TestPip_chill(unittest.TestCase):
             self.assertIn(package, result)
 
     def test_command_line_interface_short_all(self):
-        command = "pip_chill/cli.py -a"
+        argument = "-a"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -135,7 +148,8 @@ class TestPip_chill(unittest.TestCase):
             self.assertIn(package, result)
 
     def test_command_line_interface_long_all(self):
-        command = "pip_chill/cli.py --show-all"
+        argument = "--show-all"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
         self.assertEqual(returncode, 0)
@@ -145,10 +159,15 @@ class TestPip_chill(unittest.TestCase):
             self.assertIn(package, result)
 
     def test_command_line_invalid_option(self):
-        command = "pip_chill/cli.py --invalid-option"
+        argument = "--invalid-option"
+        command = " ".join([PYTHON_EXE_PATH, PIP_CHILL_CLI_FULL_PATH, argument])
 
         returncode = os.system(command)
-        self.assertEqual(returncode, 512)
+
+        if not is_windows:
+            self.assertEqual(returncode, 512)
+        else:
+            self.assertEqual(returncode, 2)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,6 @@ commands=flake8 pip_chill setup.py
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pip_chill
-deps = -rrequirements_dev.txt
+deps = -r requirements_dev.txt
 
 commands = pytest


### PR DESCRIPTION
Hi, 
I learned about your package on the python bytes podcast => https://pythonbytes.fm/episodes/show/208/dependencies-out-of-control-just-pip-chill.

They explained the use of the package but made a remark that it would be handy to not have "pip-chill" printed in the output but stated a workaround with **_grep_** for Linux or Mac users.

I, on the other hand, am a Windows user and don't have the convenient grep tool laying around.

I also have reworked your tests so they are more "cross-platformy"  and now can be run on the windows platform too
(I didn't run on Linux, but would guess it should work => the CI system will tell) (*edit: SUCCESS)

If I need to adjust something in the PR let me know, eager to help out. I noticed a few flake8 errors regarding line length in master itself dunno if I should bother too much?