### PR TITLE
adding pip-chill to the default ignored list

### DIFF
--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -55,7 +55,7 @@ def chill(show_all=False):
     if show_all:
         ignored_packages = ()
     else:
-        ignored_packages = {"pip", "wheel", "setuptools", "pkg-resources"}
+        ignored_packages = {"pip", "wheel", "setuptools", "pkg-resources", "pip-chill"}
 
     # Gather all packages that are requirements and will be auto-installed.
     distributions = {}


### PR DESCRIPTION
This would resolve issue #34

Adds pip-chill to the ignored_packages list. Keeps the idea of not adding packages to the requirements.txt file that are not needed. 