### PR TITLE
Update contributing doc

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,7 +79,7 @@ Ready to contribute? Here's how to set up `pip_chill` for local development.
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ flake8 pip_chill tests
-    $ python setup.py test or py.test
+    $ python setup.py test or pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -101,8 +101,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
-   https://travis-ci.org/rbanffy/pip_chill/pull_requests
+3. The pull request should work for Python 3.5+, and for PyPy. Check
+   https://travis-ci.com/github/rbanffy/pip-chill/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips


### PR DESCRIPTION
Use modern pytest naming (Since 3.0)
Update travis.ci link
Update supported python versions to reflect dropped support for Python 2