### PR TITLE
Fix GitHub repo URL

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/rbanffy/pip_chill/issues.
+Report bugs at https://github.com/rbanffy/pip-chill/issues.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/rbanffy/pip_chill/issues.
+The best way to send feedback is to file an issue at https://github.com/rbanffy/pip-chill/issues.
 
 If you are proposing a feature:
 
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
-   https://travis-ci.org/rbanffy/pip_chill/pull_requests
+   https://travis-ci.org/rbanffy/pip-chill/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ To install PIP Chill, run this command in your terminal:
 
     $ pip install pip_chill
 
-This is the preferred method to install PIP Chill, as it will always install the most recent stable release. 
+This is the preferred method to install PIP Chill, as it will always install the most recent stable release.
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
@@ -32,13 +32,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/rbanffy/pip_chill
+    $ git clone git://github.com/rbanffy/pip-chill
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/rbanffy/pip_chill/tarball/master
+    $ curl  -OL https://github.com/rbanffy/pip-chill/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
@@ -48,4 +48,4 @@ Once you have a copy of the source, you can install it with:
 
 
 .. _Github repo: https://github.com/rbanffy/pip-chill
-.. _tarball: https://github.com/rbanffy/pip_chill/tarball/master
+.. _tarball: https://github.com/rbanffy/pip-chill/tarball/master


### PR DESCRIPTION
The previous PR c0de0f912dcefd38825bd8395a2767a752dad51b only fixed the URL in one place.