### PR TITLE
Add setuptools req and tox py312

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Kevin Paulson https://github.com/kjwpaulson
 * Luke Skibinski https://github.com/lsh-0
 * Piotr Surowiec https://github.com/Agrendalath
+* Marcin Konowalczyk https://github.com/MarcinKonowalczyk

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+1.0.3 (...)
+------------------
+* Add dependency on `setuptools` for python >= 3.12 to get access to `pkg_resources`.
+
 1.0.2 (2023-04-15)
 ------------------
 * Sort dependencies alphabetically in --verbose

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -91,13 +91,4 @@ def chill(
                     requirement.key
                 ).version
 
-    # There are some packages which we normally ignore, but in the show_all
-    # mode we want to show. If they happen to have landed in the dependencies
-    # list we want to elevate them to the distributions list.
-    if show_all:
-        for package in {"pip", "wheel", "setuptools", "pkg-resources"}:
-            if package in dependencies and package not in distributions:
-                dep = dependencies.pop(package)
-                distributions[dep.name] = Distribution(dep.name, dep.version)
-
     return sorted(distributions.values()), sorted(dependencies.values())

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -57,7 +57,7 @@ def chill(
     show_all: bool = False, no_chill: bool = False
 ) -> "tuple[list[Distribution], list[Distribution]]":
     if show_all:
-        ignored_packages = ()
+        ignored_packages = set()
     else:
         ignored_packages = {"pip", "wheel", "setuptools", "pkg-resources"}
 

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -41,8 +41,7 @@ class Distribution:
 
     def __repr__(self):
         return (
-            f'<{self.__module__}.{self.__class__.__name__} instance "'
-            f'{self.name}">'
+            f'<{self.__module__}.{self.__class__.__name__} instance "' f'{self.name}">'
         )
 
     def __str__(self):
@@ -81,9 +80,7 @@ def chill(show_all=False, no_chill=False):
         for requirement in distribution.requires():
             if requirement.key not in ignored_packages:
                 if requirement.key in dependencies:
-                    dependencies[requirement.key].required_by.add(
-                        distribution.key
-                    )
+                    dependencies[requirement.key].required_by.add(distribution.key)
                 else:
                     dependencies[requirement.key] = Distribution(
                         requirement.key, required_by=(distribution.key,)
@@ -93,7 +90,7 @@ def chill(show_all=False, no_chill=False):
                 dependencies[requirement.key].version = distributions.pop(
                     requirement.key
                 ).version
-    
+
     # Package 'pip' is kinda special. If `show_all`` is True, we want to elevate it
     # from a dependency to a distribution, even if it is a dependency of another package.
     if show_all and "pip" in dependencies and "pip" not in distributions:

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -65,8 +65,8 @@ def chill(
         ignored_packages.add("pip-chill")
 
     # Gather all packages that are requirements and will be auto-installed.
-    distributions = {}
-    dependencies = {}
+    distributions: "dict[str, Distribution]" = {}
+    dependencies: "dict[str, Distribution]" = {}
 
     for distribution in pkg_resources.working_set:
         if distribution.key in ignored_packages:

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -93,5 +93,11 @@ def chill(show_all=False, no_chill=False):
                 dependencies[requirement.key].version = distributions.pop(
                     requirement.key
                 ).version
+    
+    # Package 'pip' is kinda special. If `show_all`` is True, we want to elevate it
+    # from a dependency to a distribution, even if it is a dependency of another package.
+    if show_all and "pip" in dependencies and "pip" not in distributions:
+        dep = dependencies.pop("pip")
+        distributions[dep.name] = Distribution(dep.name, dep.version)
 
     return sorted(distributions.values()), sorted(dependencies.values())

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -40,9 +40,7 @@ class Distribution:
         return hash(self.name)
 
     def __repr__(self):
-        return (
-            f'<{self.__module__}.{self.__class__.__name__} instance "' f'{self.name}">'
-        )
+        return f"<{self.__module__}.{self.__class__.__name__} instance '{self.name}'>"
 
     def __str__(self):
         if self.required_by:

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -53,7 +53,9 @@ class Distribution:
         return f"{self.name}=={self.version}"
 
 
-def chill(show_all=False, no_chill=False):
+def chill(
+    show_all: bool = False, no_chill: bool = False
+) -> "tuple[list[Distribution], list[Distribution]]":
     if show_all:
         ignored_packages = ()
     else:

--- a/pip_chill/pip_chill.py
+++ b/pip_chill/pip_chill.py
@@ -91,10 +91,13 @@ def chill(
                     requirement.key
                 ).version
 
-    # Package 'pip' is kinda special. If `show_all`` is True, we want to elevate it
-    # from a dependency to a distribution, even if it is a dependency of another package.
-    if show_all and "pip" in dependencies and "pip" not in distributions:
-        dep = dependencies.pop("pip")
-        distributions[dep.name] = Distribution(dep.name, dep.version)
+    # There are some packages which we normally ignore, but in the show_all
+    # mode we want to show. If they happen to have landed in the dependencies
+    # list we want to elevate them to the distributions list.
+    if show_all:
+        for package in {"pip", "wheel", "setuptools", "pkg-resources"}:
+            if package in dependencies and package not in distributions:
+                dep = dependencies.pop(package)
+                distributions[dep.name] = Distribution(dep.name, dep.version)
 
     return sorted(distributions.values()), sorted(dependencies.values())

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,4 @@ universal = 1
 
 [flake8]
 exclude = docs
+max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "setuptools",
+    "setuptools; python_version >= '3.12'",
 ]
 
 test_requirements = ["pip"]

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Environment :: Console",
-        "License :: "
-        "OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = []
+requirements = [
+    "setuptools",
+]
 
 test_requirements = ["pip"]
 

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -9,151 +9,159 @@ Tests for `pip_chill` module.
 """
 
 import os
-import sys
-import unittest
 
 from pip_chill import pip_chill
 from pip_chill.pip_chill import Distribution
 
 
-class TestPip_chill(unittest.TestCase):
-    def setUp(self):
-        self.distribution_1 = Distribution("pip-chill", "2.0.0", [])
-        self.distribution_2 = Distribution("pip", "10.0.0", [self.distribution_1])
-        self.distribution_3 = Distribution("pip", "11.0.0", [self.distribution_1])
+def test_pip_ommitted() -> None:
+    packages, _ = pip_chill.chill()
+    hidden = {"wheel", "setuptools", "pip"}
+    for package in packages:
+        assert package.name not in hidden
 
-    def tearDown(self):
-        pass
 
-    def test_pip_ommitted(self):
-        packages, _ = pip_chill.chill()
-        hidden = {"wheel", "setuptools", "pip"}
-        for package in packages:
-            self.assertNotIn(package.name, hidden)
+def test_all() -> None:
+    packages, _ = pip_chill.chill(show_all=True)
+    package_names = {package.name for package in packages}
+    for package in ["pip-chill", "pip"]:
+        assert package in package_names
 
-    def test_all(self):
-        packages, _ = pip_chill.chill(show_all=True)
-        package_names = {package.name for package in packages}
-        for package in ["pip-chill", "pip"]:
-            self.assertIn(package, package_names)
 
-    def test_hashes(self):
-        packages, _ = pip_chill.chill()
-        for package in packages:
-            self.assertEqual(hash(package), hash(package.name))
+def test_hashes() -> None:
+    packages, _ = pip_chill.chill()
+    for package in packages:
+        assert hash(package) == hash(package.name)
 
-    def test_equality(self):
-        self.assertNotEqual(self.distribution_1, self.distribution_2)
-        self.assertEqual(self.distribution_1, self.distribution_1)
-        self.assertEqual(self.distribution_2, self.distribution_3)
-        self.assertEqual(self.distribution_2, self.distribution_2.name)
 
-    def test_command_line_interface_help(self):
-        command = "pip_chill/cli.py --help"
+def test_equality() -> None:
+    d1 = Distribution("pip-chill", "2.0.0", [])
+    d2 = Distribution("pip", "10.0.0", [d1])
+    d3 = Distribution("pip", "11.0.0", [d1])
+    assert d1 != d2
+    assert d1 == d1
+    assert d2 == d3
+    assert d2 == d2.name
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
 
-        result = os.popen(command).read()
-        self.assertIn("--no-version", result)
-        self.assertIn("omit version numbers", result)
-        self.assertIn("--help", result)
-        self.assertIn("show this help message and exit", result)
+def test_command_line_interface_help() -> None:
+    command = "pip_chill/cli.py --help"
 
-    def test_command_line_interface_no_version(self):
-        command = "pip_chill/cli.py --no-version"
+    returncode = os.system(command)
+    assert returncode == 0
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+    result = os.popen(command).read()
+    assert "--no-version" in result
+    assert "omit version numbers" in result
+    assert "--help" in result
+    assert "show this help message and exit" in result
 
-        result = os.popen(command).read()
-        self.assertNotIn("==", result)
 
-    def test_command_line_interface_verbose(self):
-        command = "pip_chill/cli.py --verbose"
+def test_command_line_interface_no_version() -> None:
+    command = "pip_chill/cli.py --no-version"
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+    returncode = os.system(command)
+    assert returncode == 0
 
-        result = os.popen(command).read()
-        self.assertIn("# Installed as dependency for", result)
+    result = os.popen(command).read()
+    assert "==" not in result
 
-    def test_command_line_interface_short_verbose(self):
-        command = "pip_chill/cli.py -v"
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+def test_command_line_interface_verbose() -> None:
+    command = "pip_chill/cli.py --verbose"
 
-        result = os.popen(command).read()
-        self.assertIn("# Installed as dependency for", result)
+    returncode = os.system(command)
+    assert returncode == 0
 
-    def test_command_line_interface_verbose_no_version(self):
-        command = "pip_chill/cli.py --verbose --no-version"
+    result = os.popen(command).read()
+    assert "# Installed as dependency for" in result
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
 
-        result = os.popen(command).read()
-        self.assertNotIn("==", result)
-        self.assertIn("# Installed as dependency for", result)
+def test_command_line_interface_short_verbose() -> None:
+    command = "pip_chill/cli.py -v"
 
-    def test_command_line_interface_omits_ignored(self):
-        command = "pip_chill/cli.py"
+    returncode = os.system(command)
+    assert returncode == 0
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+    result = os.popen(command).read()
+    assert "# Installed as dependency for" in result
 
-        result = os.popen(command).read()
-        for package in ["wheel", "setuptools", "pip"]:
-            self.assertFalse(
-                any(p.startswith(f"{package}==") for p in result.split("\n"))
-            )
 
-    def test_command_line_interface_all(self):
-        command = "pip_chill/cli.py --all"
+def test_command_line_interface_verbose_no_version() -> None:
+    command = "pip_chill/cli.py --verbose --no-version"
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+    returncode = os.system(command)
+    assert returncode == 0
 
-        result = os.popen(command).read()
-        for package in ["pip-chill", "pip"]:
-            self.assertIn(package, result)
+    result = os.popen(command).read()
+    assert "==" not in result
+    assert "# Installed as dependency for" in result
 
-    def test_command_line_interface_short_all(self):
-        command = "pip_chill/cli.py -a"
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+def test_command_line_interface_omits_ignored() -> None:
+    command = "pip_chill/cli.py"
 
-        result = os.popen(command).read()
-        for package in ["pip-chill", "pip"]:
-            self.assertIn(package, result)
+    returncode = os.system(command)
+    assert returncode == 0
 
-    def test_command_line_interface_long_all(self):
-        command = "pip_chill/cli.py --show-all"
+    result = os.popen(command).read()
+    for package in ["wheel", "setuptools", "pip"]:
+        #     any(p.startswith(f"{package}==") for p in result.split("\n"))
+        # )
+        assert not any(p.startswith(f"{package}==") for p in result.split("\n"))
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
 
-        result = os.popen(command).read()
-        for package in ["pip-chill", "pip"]:
-            self.assertIn(package, result)
+def test_command_line_interface_all() -> None:
+    command = "pip_chill/cli.py --all"
 
-    def test_command_line_interface_no_chill(self):
-        command = "pip_chill/cli.py --no-chill"
+    returncode = os.system(command)
+    assert returncode == 0
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 0)
+    result = os.popen(command).read()
+    for package in ["pip-chill", "pip"]:
+        assert package in result
 
-        result = os.popen(command).read()
-        self.assertNotIn("pip-chill", result)
 
-    def test_command_line_invalid_option(self):
-        command = "pip_chill/cli.py --invalid-option"
+def test_command_line_interface_short_all() -> None:
+    command = "pip_chill/cli.py -a"
 
-        returncode = os.system(command)
-        self.assertEqual(returncode, 512)
+    returncode = os.system(command)
+    assert returncode == 0
+
+    result = os.popen(command).read()
+    for package in ["pip-chill", "pip"]:
+        assert package in result
+
+
+def test_command_line_interface_long_all() -> None:
+    command = "pip_chill/cli.py --show-all"
+
+    returncode = os.system(command)
+    assert returncode == 0
+
+    result = os.popen(command).read()
+    for package in ["pip-chill", "pip"]:
+        assert package in result
+
+
+def test_command_line_interface_no_chill() -> None:
+    command = "pip_chill/cli.py --no-chill"
+
+    returncode = os.system(command)
+    assert returncode == 0
+
+    result = os.popen(command).read()
+    assert "pip-chill" not in result
+
+
+def test_command_line_invalid_option() -> None:
+    command = "pip_chill/cli.py --invalid-option"
+
+    returncode = os.system(command)
+    assert returncode == 512
 
 
 if __name__ == "__main__":
-    sys.exit(unittest.main())
+    import pytest
+
+    pytest.main([__file__])

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -8,7 +8,6 @@ test_pip_chill
 Tests for `pip_chill` module.
 """
 
-
 import os
 import sys
 import unittest
@@ -20,12 +19,8 @@ from pip_chill.pip_chill import Distribution
 class TestPip_chill(unittest.TestCase):
     def setUp(self):
         self.distribution_1 = Distribution("pip-chill", "2.0.0", [])
-        self.distribution_2 = Distribution(
-            "pip", "10.0.0", [self.distribution_1]
-        )
-        self.distribution_3 = Distribution(
-            "pip", "11.0.0", [self.distribution_1]
-        )
+        self.distribution_2 = Distribution("pip", "10.0.0", [self.distribution_1])
+        self.distribution_3 = Distribution("pip", "11.0.0", [self.distribution_1])
 
     def tearDown(self):
         pass
@@ -110,7 +105,9 @@ class TestPip_chill(unittest.TestCase):
 
         result = os.popen(command).read()
         for package in ["wheel", "setuptools", "pip"]:
-            self.assertFalse(any(p.startswith(f"{package}==") for p in result.split("\n")))
+            self.assertFalse(
+                any(p.startswith(f"{package}==") for p in result.split("\n"))
+            )
 
     def test_command_line_interface_all(self):
         command = "pip_chill/cli.py --all"

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -9,159 +9,151 @@ Tests for `pip_chill` module.
 """
 
 import os
+import sys
+import unittest
 
 from pip_chill import pip_chill
 from pip_chill.pip_chill import Distribution
 
 
-def test_pip_ommitted() -> None:
-    packages, _ = pip_chill.chill()
-    hidden = {"wheel", "setuptools", "pip"}
-    for package in packages:
-        assert package.name not in hidden
+class TestPip_chill(unittest.TestCase):
+    def setUp(self):
+        self.distribution_1 = Distribution("pip-chill", "2.0.0", [])
+        self.distribution_2 = Distribution("pip", "10.0.0", [self.distribution_1])
+        self.distribution_3 = Distribution("pip", "11.0.0", [self.distribution_1])
 
+    def tearDown(self):
+        pass
 
-def test_all() -> None:
-    packages, _ = pip_chill.chill(show_all=True)
-    package_names = {package.name for package in packages}
-    for package in ["pip-chill", "pip"]:
-        assert package in package_names
+    def test_pip_ommitted(self):
+        packages, _ = pip_chill.chill()
+        hidden = {"wheel", "setuptools", "pip"}
+        for package in packages:
+            self.assertNotIn(package.name, hidden)
 
+    def test_all(self):
+        packages, _ = pip_chill.chill(show_all=True)
+        package_names = {package.name for package in packages}
+        for package in ["pip-chill", "pip"]:
+            self.assertIn(package, package_names)
 
-def test_hashes() -> None:
-    packages, _ = pip_chill.chill()
-    for package in packages:
-        assert hash(package) == hash(package.name)
+    def test_hashes(self):
+        packages, _ = pip_chill.chill()
+        for package in packages:
+            self.assertEqual(hash(package), hash(package.name))
 
+    def test_equality(self):
+        self.assertNotEqual(self.distribution_1, self.distribution_2)
+        self.assertEqual(self.distribution_1, self.distribution_1)
+        self.assertEqual(self.distribution_2, self.distribution_3)
+        self.assertEqual(self.distribution_2, self.distribution_2.name)
 
-def test_equality() -> None:
-    d1 = Distribution("pip-chill", "2.0.0", [])
-    d2 = Distribution("pip", "10.0.0", [d1])
-    d3 = Distribution("pip", "11.0.0", [d1])
-    assert d1 != d2
-    assert d1 == d1
-    assert d2 == d3
-    assert d2 == d2.name
+    def test_command_line_interface_help(self):
+        command = "pip_chill/cli.py --help"
 
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-def test_command_line_interface_help() -> None:
-    command = "pip_chill/cli.py --help"
+        result = os.popen(command).read()
+        self.assertIn("--no-version", result)
+        self.assertIn("omit version numbers", result)
+        self.assertIn("--help", result)
+        self.assertIn("show this help message and exit", result)
 
-    returncode = os.system(command)
-    assert returncode == 0
+    def test_command_line_interface_no_version(self):
+        command = "pip_chill/cli.py --no-version"
 
-    result = os.popen(command).read()
-    assert "--no-version" in result
-    assert "omit version numbers" in result
-    assert "--help" in result
-    assert "show this help message and exit" in result
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
+        result = os.popen(command).read()
+        self.assertNotIn("==", result)
 
-def test_command_line_interface_no_version() -> None:
-    command = "pip_chill/cli.py --no-version"
+    def test_command_line_interface_verbose(self):
+        command = "pip_chill/cli.py --verbose"
 
-    returncode = os.system(command)
-    assert returncode == 0
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-    result = os.popen(command).read()
-    assert "==" not in result
+        result = os.popen(command).read()
+        self.assertIn("# Installed as dependency for", result)
 
+    def test_command_line_interface_short_verbose(self):
+        command = "pip_chill/cli.py -v"
 
-def test_command_line_interface_verbose() -> None:
-    command = "pip_chill/cli.py --verbose"
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-    returncode = os.system(command)
-    assert returncode == 0
+        result = os.popen(command).read()
+        self.assertIn("# Installed as dependency for", result)
 
-    result = os.popen(command).read()
-    assert "# Installed as dependency for" in result
+    def test_command_line_interface_verbose_no_version(self):
+        command = "pip_chill/cli.py --verbose --no-version"
 
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-def test_command_line_interface_short_verbose() -> None:
-    command = "pip_chill/cli.py -v"
+        result = os.popen(command).read()
+        self.assertNotIn("==", result)
+        self.assertIn("# Installed as dependency for", result)
 
-    returncode = os.system(command)
-    assert returncode == 0
+    def test_command_line_interface_omits_ignored(self):
+        command = "pip_chill/cli.py"
 
-    result = os.popen(command).read()
-    assert "# Installed as dependency for" in result
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
+        result = os.popen(command).read()
+        for package in ["wheel", "setuptools", "pip"]:
+            self.assertFalse(
+                any(p.startswith(f"{package}==") for p in result.split("\n"))
+            )
 
-def test_command_line_interface_verbose_no_version() -> None:
-    command = "pip_chill/cli.py --verbose --no-version"
+    def test_command_line_interface_all(self):
+        command = "pip_chill/cli.py --all"
 
-    returncode = os.system(command)
-    assert returncode == 0
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-    result = os.popen(command).read()
-    assert "==" not in result
-    assert "# Installed as dependency for" in result
+        result = os.popen(command).read()
+        for package in ["pip-chill", "pip"]:
+            self.assertIn(package, result)
 
+    def test_command_line_interface_short_all(self):
+        command = "pip_chill/cli.py -a"
 
-def test_command_line_interface_omits_ignored() -> None:
-    command = "pip_chill/cli.py"
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-    returncode = os.system(command)
-    assert returncode == 0
+        result = os.popen(command).read()
+        for package in ["pip-chill", "pip"]:
+            self.assertIn(package, result)
 
-    result = os.popen(command).read()
-    for package in ["wheel", "setuptools", "pip"]:
-        #     any(p.startswith(f"{package}==") for p in result.split("\n"))
-        # )
-        assert not any(p.startswith(f"{package}==") for p in result.split("\n"))
+    def test_command_line_interface_long_all(self):
+        command = "pip_chill/cli.py --show-all"
 
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
-def test_command_line_interface_all() -> None:
-    command = "pip_chill/cli.py --all"
+        result = os.popen(command).read()
+        for package in ["pip-chill", "pip"]:
+            self.assertIn(package, result)
 
-    returncode = os.system(command)
-    assert returncode == 0
+    def test_command_line_interface_no_chill(self):
+        command = "pip_chill/cli.py --no-chill"
 
-    result = os.popen(command).read()
-    for package in ["pip-chill", "pip"]:
-        assert package in result
+        returncode = os.system(command)
+        self.assertEqual(returncode, 0)
 
+        result = os.popen(command).read()
+        self.assertNotIn("pip-chill", result)
 
-def test_command_line_interface_short_all() -> None:
-    command = "pip_chill/cli.py -a"
+    def test_command_line_invalid_option(self):
+        command = "pip_chill/cli.py --invalid-option"
 
-    returncode = os.system(command)
-    assert returncode == 0
-
-    result = os.popen(command).read()
-    for package in ["pip-chill", "pip"]:
-        assert package in result
-
-
-def test_command_line_interface_long_all() -> None:
-    command = "pip_chill/cli.py --show-all"
-
-    returncode = os.system(command)
-    assert returncode == 0
-
-    result = os.popen(command).read()
-    for package in ["pip-chill", "pip"]:
-        assert package in result
-
-
-def test_command_line_interface_no_chill() -> None:
-    command = "pip_chill/cli.py --no-chill"
-
-    returncode = os.system(command)
-    assert returncode == 0
-
-    result = os.popen(command).read()
-    assert "pip-chill" not in result
-
-
-def test_command_line_invalid_option() -> None:
-    command = "pip_chill/cli.py --invalid-option"
-
-    returncode = os.system(command)
-    assert returncode == 512
+        returncode = os.system(command)
+        self.assertEqual(returncode, 512)
 
 
 if __name__ == "__main__":
-    import pytest
-
-    pytest.main([__file__])
+    sys.exit(unittest.main())

--- a/tests/test_pip_chill.py
+++ b/tests/test_pip_chill.py
@@ -37,7 +37,7 @@ class TestPip_chill(unittest.TestCase):
             self.assertNotIn(package.name, hidden)
 
     def test_all(self):
-        packages, _ = pip_chill.chill(True)
+        packages, _ = pip_chill.chill(show_all=True)
         package_names = {package.name for package in packages}
         for package in ["pip-chill", "pip"]:
             self.assertIn(package, package_names)

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+min_version = 4.0
 envlist = py37, py38, py39, py310, py311, py312, bandit, flake8
 
 [testenv:bandit]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=bandit
 commands=bandit -r pip_chill *.py
 
 [testenv:flake8]
-basepython=python
+basepython=python3
 deps=flake8
 commands=flake8 pip_chill setup.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, bandit, flake8
+envlist = py37, py38, py39, py310, py311, py312, bandit, flake8
 
 [testenv:bandit]
 basepython=python3


### PR DESCRIPTION
Resolves #74 in the easy way (add `setuptools` dep for py>3.12).

Also encountered a failing test with `--show-all` option in test_pip_chill::TestPip_chill::test_all (line 34). It requires both `pip-chill` and `pip` to appear in the output, but that's not true if `pip` is a dependency (e.g. of package `pip-autoremove`). I've added a bit to elevate `pip` (as well as the other "special" packages) to distributions list (also explained in a comment).